### PR TITLE
Add option to disable file bases logging

### DIFF
--- a/beacon/conf/conf.py
+++ b/beacon/conf/conf.py
@@ -11,6 +11,7 @@ except Exception as e:# pragma: no cover
     raise_exception(err, errcode)
 
 level=logging.NOTSET
+log_file='beacon/logs/logs.log'
 api_version='2.0.0'
 default_beacon_granularity='record'
 beacon_id = 'org.ega-archive.beacon-ri-demo'  # ID of the Beacon

--- a/beacon/logs/logs.py
+++ b/beacon/logs/logs.py
@@ -1,17 +1,24 @@
 import logging
 import time
 from beacon.conf.conf import level
+from beacon.conf.conf import log_file
 from typing import Optional
 import os
 
 LOG = logging.getLogger(__name__)
-fh = logging.FileHandler("beacon/logs/logs.log")
-fh.setLevel(level)
 fmt = '%(levelname)s - %(asctime)s - %(message)s'
 formatter = logging.Formatter(fmt)
-fh.setFormatter(formatter)
-LOG.addHandler(fh)
 
+if log_file:
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(level)
+    fh.setFormatter(formatter)
+    LOG.addHandler(fh)
+else:
+    sh = logging.StreamHandler()
+    sh.setLevel(level)
+    sh.setFormatter(formatter)
+    LOG.addHandler(sh)
 
 # LOGS per iniciar i parar el contenidor (INFO)
 # LOGS per he rebut una request i retorno una response (INFO)


### PR DESCRIPTION
On systems that collect logs form docker central logs or the containers sdtout logging to a file inside the container has no value. This also makes the container work on systems that requires unprivileged runtime users or read only container file system.
