### PR TITLE
Add Support for mongo+srv Connection String in MongoDB Configuration

### DIFF
--- a/beacon/connections/mongo/__init__.py
+++ b/beacon/connections/mongo/__init__.py
@@ -2,11 +2,21 @@ from pymongo.mongo_client import MongoClient
 from beacon.connections.mongo import conf
 import os
 
-uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
-    conf.database_user,
-    conf.database_password,
-    conf.database_host
-)
+if conf.database_cluster:
+    uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host
+    )
+else:
+    uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host,
+        conf.database_port,
+        conf.database_name,
+        conf.database_auth_source
+    )
 
 if os.path.isfile(conf.database_certificate):
     uri += '&tls=true&tlsCertificateKeyFile={}'.format(conf.database_certificate)

--- a/beacon/connections/mongo/__init__.py
+++ b/beacon/connections/mongo/__init__.py
@@ -2,13 +2,10 @@ from pymongo.mongo_client import MongoClient
 from beacon.connections.mongo import conf
 import os
 
-uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
     conf.database_user,
     conf.database_password,
-    conf.database_host,
-    conf.database_port,
-    conf.database_name,
-    conf.database_auth_source
+    conf.database_host
 )
 
 if os.path.isfile(conf.database_certificate):

--- a/beacon/connections/mongo/conf.py
+++ b/beacon/connections/mongo/conf.py
@@ -6,3 +6,4 @@ database_name = 'beacon'
 database_auth_source = 'admin'
 database_certificate = ''
 database_cafile = ''
+database_cluster = True

--- a/beacon/connections/mongo/conf.py
+++ b/beacon/connections/mongo/conf.py
@@ -1,7 +1,7 @@
-database_host = 'mongo' #'host.docker.internal'
+database_host = 'healthri-beacon.global.mongocluster.cosmos.azure.com' #'host.docker.internal'
 database_port = 27017
-database_user = 'root'
-database_password = 'example'
+database_user = 'healthri'
+database_password = 'bikfab-koxviz-wamDi2'
 database_name = 'beacon'
 database_auth_source = 'admin'
 database_certificate = ''

--- a/beacon/connections/mongo/conf.py
+++ b/beacon/connections/mongo/conf.py
@@ -1,9 +1,8 @@
-database_host = 'healthri-beacon.global.mongocluster.cosmos.azure.com' #'host.docker.internal'
+database_host = 'mongo' #'host.docker.internal'
 database_port = 27017
-database_user = 'healthri'
-database_password = 'bikfab-koxviz-wamDi2'
+database_user = 'root'
+database_password = 'example'
 database_name = 'beacon'
 database_auth_source = 'admin'
 database_certificate = ''
 database_cafile = ''
-database_cluster = True

--- a/beacon/connections/mongo/conf.py
+++ b/beacon/connections/mongo/conf.py
@@ -6,3 +6,4 @@ database_name = 'beacon'
 database_auth_source = 'admin'
 database_certificate = ''
 database_cafile = ''
+database_cluster = False

--- a/beacon/connections/mongo/extract_filtering_terms.py
+++ b/beacon/connections/mongo/extract_filtering_terms.py
@@ -28,14 +28,21 @@ ONTOLOGY_REGEX = re.compile(r"([_A-Za-z0-9]+):([_A-Za-z0-9^\-]+)")
 ICD_REGEX = re.compile(r"(ICD[_A-Za-z0-9]+):([_A-Za-z0-9^\./-]+)")
 
 
-uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
-    conf.database_user,
-    conf.database_password,
-    conf.database_host,
-    conf.database_port,
-    conf.database_name,
-    conf.database_auth_source
-)
+if conf.database_cluster:
+    uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host
+    )
+else:
+    uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host,
+        conf.database_port,
+        conf.database_name,
+        conf.database_auth_source
+    )
 
 if os.path.isfile(conf.database_certificate):
     uri += '&tls=true&tlsCertificateKeyFile={}'.format(conf.database_certificate)

--- a/beacon/connections/mongo/get_descendants.py
+++ b/beacon/connections/mongo/get_descendants.py
@@ -13,14 +13,21 @@ import os
 import conf
 
 
-uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
-    conf.database_user,
-    conf.database_password,
-    conf.database_host,
-    conf.database_port,
-    conf.database_name,
-    conf.database_auth_source
-)
+if conf.database_cluster:
+    uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host
+    )
+else:
+    uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host,
+        conf.database_port,
+        conf.database_name,
+        conf.database_auth_source
+    )
 
 if os.path.isfile(conf.database_certificate):
     uri += '&tls=true&tlsCertificateKeyFile={}'.format(conf.database_certificate)

--- a/beacon/connections/mongo/ping.py
+++ b/beacon/connections/mongo/ping.py
@@ -5,14 +5,21 @@ import os
 from beacon.logs.logs import LOG
 
 
-uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
-    conf.database_user,
-    conf.database_password,
-    conf.database_host,
-    conf.database_port,
-    conf.database_name,
-    conf.database_auth_source
-)
+if conf.database_cluster:
+    uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host
+    )
+else:
+    uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host,
+        conf.database_port,
+        conf.database_name,
+        conf.database_auth_source
+    )
 
 if os.path.isfile(conf.database_certificate):
     uri += '&tls=true&tlsCertificateKeyFile={}'.format(conf.database_certificate)

--- a/beacon/connections/mongo/reindex.py
+++ b/beacon/connections/mongo/reindex.py
@@ -3,14 +3,21 @@ import conf
 import os
 
 
-uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
-    conf.database_user,
-    conf.database_password,
-    conf.database_host,
-    conf.database_port,
-    conf.database_name,
-    conf.database_auth_source
-)
+if conf.database_cluster:
+    uri = "mongodb+srv://{}:{}@{}/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host
+    )
+else:
+    uri = "mongodb://{}:{}@{}:{}/{}?authSource={}".format(
+        conf.database_user,
+        conf.database_password,
+        conf.database_host,
+        conf.database_port,
+        conf.database_name,
+        conf.database_auth_source
+    )
 
 if os.path.isfile(conf.database_certificate):
     uri += '&tls=true&tlsCertificateKeyFile={}'.format(conf.database_certificate)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jsonschema-specifications==2023.12.1
 loguru==0.7.2
 pyyaml==6.0.1
 dataclasses-json==0.5.6
-pymongo==4.0.1
+pymongo[srv]==4.0.1
 coverage==7.6.0
 requests==2.25.1
 pydantic==2.6.2


### PR DESCRIPTION
- It enhances the database configuration logic to recognize and handle the mongo+srv URI format, allowing connections to MongoDB clusters that use DNS-based seed lists.
- The existing connection mechanism using the standard MongoDB protocol (mongodb://) remains fully functional.
- Updates were made to the configuration parsing to differentiate between mongo and mongo+srv protocols, ensuring seamless operation for both types of connection strings.
- No breaking changes; backward compatibility with previous configurations is maintained.